### PR TITLE
Makefile - implement destroy and destroy-all

### DIFF
--- a/single-account-single-cluster-multi-env/Makefile
+++ b/single-account-single-cluster-multi-env/Makefile
@@ -10,8 +10,13 @@ VAR_FILE := $(CURDIR)/00.global/vars/$(ENVIRONMENT).tfvars
 
 MODULES = $(shell find . -type f -name "backend.tf" -exec dirname {} \; | sort -u )
 
-.PHONY: print-modules clean check-env bootstrap init-all plan-all apply-all init plan apply destroy
+ifeq ($(AUTO_APPROVE), true)
+	TF_AUTO_APPROVE := "-auto-approve"
+else
+	TF_AUTO_APPROVE := ""
+endif
 
+.PHONY: print-modules clean check-env bootstrap init-all plan-all apply-all destroy-all init plan apply destroy
 
 print-modules:
 	@for m in $(MODULES); do echo $$m; done
@@ -59,6 +64,13 @@ apply-all:
   		$(MAKE) apply MODULE=$$m || exit 1; \
   	done
 
+destroy-all: MODULES := $(shell find . -type f -name "backend.tf" -exec dirname {} \; | sort -r )
+destroy-all:
+	@for m in $(MODULES); do \
+  		$(MAKE) destroy MODULE=$$m || exit 1; \
+  	done
+
+
 init: check-env
 	@if [ -z $(MODULE) ]; then \
 		echo "MODULE was not set."; \
@@ -103,6 +115,7 @@ apply: init tf-select-ws
 destroy: init tf-select-ws
 	@echo ENVIRONMENT=$(ENVIRONMENT) MODULE=$(MODULE) terraform::destroy
 	@terraform -chdir=$(MODULE) destroy \
+	$(TF_AUTO_APPROVE) \
 	-input=false \
 	-lock=true \
 	-var-file=$(VAR_FILE) \

--- a/single-account-single-cluster-multi-env/README.md
+++ b/single-account-single-cluster-multi-env/README.md
@@ -107,5 +107,21 @@ export AWS_PROFILE=default
 make ENVIRONMENT=dev MODULE=10.networking apply 
 ```
 
-### Step 4 - Cleanup
-We currently do not implement the destroy all command
+### Step 4 - Cleanup - destroy
+Be caution when using destroy to cleanup resources.
+By default, the destroy `-auto-approve` is disabled, to enable it, use the `AUTO_APPROVE=true` variable.
+
+```
+export AWS_REGION=us-east-1
+export AWS_PROFILE=default
+make ENVIRONMENT=dev MODULE=10.networking destroy AUTO_APPROVE=true 
+```
+
+#### Destroy ALL
+This will run Terraform destroy on all modules by reverse order.
+
+```
+export AWS_REGION=us-east-1
+export AWS_PROFILE=default
+make ENVIRONMENT=dev destroy-all AUTO_APPROVE=true 
+```


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR implement a destroy-all.
It will destroy module in reverse priority.
By default "-auto-approve" is not used.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
