### PR TITLE
EKS 1.32 support

### DIFF
--- a/single-account-single-cluster-multi-env/00.global/vars/dev.tfvars
+++ b/single-account-single-cluster-multi-env/00.global/vars/dev.tfvars
@@ -10,14 +10,25 @@ shared_config = {
 }
 
 cluster_config = {
-  kubernetes_version  = "1.29"
+  kubernetes_version  = "1.32"
   private_eks_cluster = false
+  create_mng_system   = true // CriticalAddons MNG NodeGroup
+  capabilities = {
+    kube_proxy    = true // kube proxy
+    networking    = true // VPC CNI
+    coredns       = true // CoreDNS
+    identity      = true // Pod Identity
+    autoscaling   = true // Karpenter
+    blockstorage  = true // EBS CSI Driver
+    loadbalancing = true // LB Controller
+    gitops        = true // ArgocD
+  }
 }
 
 # Observability variables 
 observability_configuration = {
   aws_oss_tooling    = false
-  aws_native_tooling = false
+  aws_native_tooling = true
   aws_oss_tooling_config = {
     enable_managed_collector = false
     enable_adot_collector    = false

--- a/single-account-single-cluster-multi-env/30.eks/30.cluster/karpenter.tf
+++ b/single-account-single-cluster-multi-env/30.eks/30.cluster/karpenter.tf
@@ -16,7 +16,7 @@ resource "aws_ec2_tag" "cluster_primary_security_group" {
 ################################################################################
 module "karpenter" {
   source  = "terraform-aws-modules/eks/aws//modules/karpenter"
-  version = "~> 20.31.3"
+  version = "~> 20.33.1"
 
   create = local.capabilities.autoscaling
 
@@ -57,7 +57,7 @@ resource "helm_release" "karpenter" {
   repository_username = data.aws_ecrpublic_authorization_token.token.user_name
   repository_password = data.aws_ecrpublic_authorization_token.token.password
   chart               = "karpenter"
-  version             = "1.1.1"
+  version             = "1.1.2"
   wait                = false
 
   values = [

--- a/single-account-single-cluster-multi-env/30.eks/30.cluster/locals.tf
+++ b/single-account-single-cluster-multi-env/30.eks/30.cluster/locals.tf
@@ -1,7 +1,6 @@
 locals {
   cluster_name    = "${var.shared_config.resources_prefix}-${terraform.workspace}"
   region          = data.aws_region.current.id
-  tfstate_region  = try(var.tfstate_region, local.region)
   cluster_version = var.cluster_config.kubernetes_version
   eks_auto_mode   = try(var.cluster_config.eks_auto_mode, false)
 

--- a/single-account-single-cluster-multi-env/30.eks/30.cluster/remote_state.tf
+++ b/single-account-single-cluster-multi-env/30.eks/30.cluster/remote_state.tf
@@ -1,11 +1,10 @@
-
 data "terraform_remote_state" "vpc" {
   backend   = "s3"
   workspace = terraform.workspace
   config = {
-    bucket = "tfstate-${data.aws_caller_identity.current.account_id}"
+    bucket = "${var.shared_config.resources_prefix}-tfstate-${data.aws_caller_identity.current.account_id}"
     key    = "networking/vpc/terraform.tfstate"
-    region = local.tfstate_region
+    region = local.region
   }
 }
 
@@ -13,9 +12,9 @@ data "terraform_remote_state" "iam" {
   backend   = "s3"
   workspace = terraform.workspace
   config = {
-    bucket = "tfstate-${data.aws_caller_identity.current.account_id}"
+    bucket = "${var.shared_config.resources_prefix}-tfstate-${data.aws_caller_identity.current.account_id}"
     key    = "iam/roles/terraform.tfstate"
-    region = local.tfstate_region
+    region = local.region
   }
 }
 

--- a/single-account-single-cluster-multi-env/30.eks/30.cluster/variables.tf
+++ b/single-account-single-cluster-multi-env/30.eks/30.cluster/variables.tf
@@ -1,14 +1,7 @@
-variable "tfstate_region" {
-  description = "region where the terraform state is stored"
-  type        = string
-  default     = null
-}
-
 variable "kms_key_admin_roles" {
   description = "list of role ARNs to add to the KMS policy"
   type        = list(string)
   default     = []
-
 }
 
 variable "tags" {

--- a/single-account-single-cluster-multi-env/30.eks/35.addons/locals.tf
+++ b/single-account-single-cluster-multi-env/30.eks/35.addons/locals.tf
@@ -1,6 +1,6 @@
 locals {
-  region         = data.aws_region.current.id
-  tfstate_region = try(var.tfstate_region, local.region)
+  region = data.aws_region.current.id
+  cluster_name = data.terraform_remote_state.eks.outputs.cluster_name
   eks_auto_mode  = try(var.cluster_config.eks_auto_mode, false)
 
   capabilities = {
@@ -17,7 +17,6 @@ locals {
       }
     ]
   }
-
   tags = merge(
     var.tags,
     {

--- a/single-account-single-cluster-multi-env/30.eks/35.addons/remote_state.tf
+++ b/single-account-single-cluster-multi-env/30.eks/35.addons/remote_state.tf
@@ -2,8 +2,8 @@ data "terraform_remote_state" "eks" {
   backend   = "s3"
   workspace = terraform.workspace
   config = {
-    bucket = "tfstate-${data.aws_caller_identity.current.account_id}"
+    bucket = "${var.shared_config.resources_prefix}-tfstate-${data.aws_caller_identity.current.account_id}"
     key    = "eks/terraform.tfstate"
-    region = local.tfstate_region
+    region = local.region
   }
 }

--- a/single-account-single-cluster-multi-env/30.eks/35.addons/variables.tf
+++ b/single-account-single-cluster-multi-env/30.eks/35.addons/variables.tf
@@ -16,6 +16,12 @@ variable "cluster_config" {
   default     = {}
 }
 
+variable "shared_config" {
+  description = "Shared configuration across all modules/folders"
+  type        = map(any)
+  default     = {}
+}
+
 variable "observability_configuration" {
   description = "observability configuration variable"
   type = object({

--- a/single-account-single-cluster-multi-env/40.observability/40.aws-native-observability/locals.tf
+++ b/single-account-single-cluster-multi-env/40.observability/40.aws-native-observability/locals.tf
@@ -1,7 +1,7 @@
 locals {
-  region         = data.aws_region.current.id
-  tfstate_region = try(var.tfstate_region, local.region)
-
+  region = data.aws_region.current.id
+  cluster_name = data.terraform_remote_state.eks.outputs.cluster_name
+  
   tags = merge(
     var.tags,
     {

--- a/single-account-single-cluster-multi-env/40.observability/40.aws-native-observability/remote_state.tf
+++ b/single-account-single-cluster-multi-env/40.observability/40.aws-native-observability/remote_state.tf
@@ -2,8 +2,8 @@ data "terraform_remote_state" "eks" {
   backend   = "s3"
   workspace = terraform.workspace
   config = {
-    bucket = "tfstate-${data.aws_caller_identity.current.account_id}"
+    bucket = "${var.shared_config.resources_prefix}-tfstate-${data.aws_caller_identity.current.account_id}"
     key    = "eks/terraform.tfstate"
-    region = local.tfstate_region
+    region = local.region
   }
 }

--- a/single-account-single-cluster-multi-env/40.observability/40.aws-native-observability/variables.tf
+++ b/single-account-single-cluster-multi-env/40.observability/40.aws-native-observability/variables.tf
@@ -10,6 +10,12 @@ variable "tags" {
   default     = {}
 }
 
+variable "shared_config" {
+  description = "Shared configuration across all modules/folders"
+  type        = map(any)
+  default     = {}
+}
+
 variable "observability_configuration" {
   description = "observability configuration variable"
   type = object({

--- a/single-account-single-cluster-multi-env/40.observability/45.aws-oss-observability/locals.tf
+++ b/single-account-single-cluster-multi-env/40.observability/45.aws-oss-observability/locals.tf
@@ -2,7 +2,7 @@ locals {
 
   name = "${var.shared_config.resources_prefix}-${terraform.workspace}"
 
-  region         = data.aws_region.current.name
+  region = data.aws_region.current.id
   sso_region     = try(var.observability_configuration.aws_oss_tooling_config.sso_region, local.region)
   tfstate_region = try(var.tfstate_region, local.region)
 

--- a/single-account-single-cluster-multi-env/40.observability/45.aws-oss-observability/remote_state.tf
+++ b/single-account-single-cluster-multi-env/40.observability/45.aws-oss-observability/remote_state.tf
@@ -2,9 +2,9 @@ data "terraform_remote_state" "vpc" {
   backend   = "s3"
   workspace = terraform.workspace
   config = {
-    bucket = "tfstate-${data.aws_caller_identity.current.account_id}"
+    bucket = "${var.shared_config.resources_prefix}-tfstate-${data.aws_caller_identity.current.account_id}"
     key    = "networking/vpc/terraform.tfstate"
-    region = local.tfstate_region
+    region = local.region
   }
 }
 
@@ -12,9 +12,9 @@ data "terraform_remote_state" "eks" {
   backend   = "s3"
   workspace = terraform.workspace
   config = {
-    bucket = "tfstate-${data.aws_caller_identity.current.account_id}"
+    bucket = "${var.shared_config.resources_prefix}-tfstate-${data.aws_caller_identity.current.account_id}"
     key    = "eks/terraform.tfstate"
-    region = local.tfstate_region
+    region = local.region
   }
 }
 
@@ -22,8 +22,8 @@ data "terraform_remote_state" "eks_addons" {
   backend   = "s3"
   workspace = terraform.workspace
   config = {
-    bucket = "tfstate-${data.aws_caller_identity.current.account_id}"
+    bucket = "${var.shared_config.resources_prefix}-tfstate-${data.aws_caller_identity.current.account_id}"
     key    = "eks-addons/terraform.tfstate"
-    region = local.tfstate_region
+    region = local.region
   }
 }

--- a/single-account-single-cluster-multi-env/Makefile
+++ b/single-account-single-cluster-multi-env/Makefile
@@ -5,10 +5,11 @@ SHELLFLAGS = -o pipefail
 ENVIRONMENT ?= dev
 AWS_REGION ?= $(shell aws configure get region)
 AWS_ACCOUNT_ID ?= $(shell aws sts get-caller-identity --output json | jq -r '.Account')
-TFSTATE_S3_BUCKET ?= "tfstate-$(AWS_ACCOUNT_ID)"
+VAR_FILE := $(CURDIR)/00.global/vars/$(ENVIRONMENT).tfvars
+RESOURCES_PREFIX ?= $(shell awk -F '=' '/resources_prefix/{gsub(/[" \t]|\/\/.*$$/, "", $$2); print $$2}' $(VAR_FILE))
+TFSTATE_S3_BUCKET ?= $(RESOURCES_PREFIX)-tfstate-$(AWS_ACCOUNT_ID)
 TFSTATE_REGION ?= $(AWS_REGION)
 TFSTATE_DDB_TABLE ?= "tfstate-lock"
-VAR_FILE := $(CURDIR)/00.global/vars/$(ENVIRONMENT).tfvars
 
 TF_VAR_tfstate_region := $(TFSTATE_REGION)
 export TF_VAR_tfstate_region
@@ -55,7 +56,12 @@ check-env:
 	 fi
 	@if [ ! -f $(VAR_FILE) ]; then \
   		echo "VAR_FILE: $(VAR_FILE) does not exist."; \
+		exit 1; \
   	fi
+	@if [ -z "$(RESOURCES_PREFIX)" ]; then \
+		echo "Failed to extract RESOURCES_PREFIX from $(VAR_FILE)"; \
+		exit 1; \
+	fi
 
 	@mkdir -p tf-logs
 
@@ -69,7 +75,13 @@ bootstrap: check-env
 		aws s3api put-bucket-acl --region $(TFSTATE_REGION) --bucket $(TFSTATE_S3_BUCKET) --acl private > /dev/null 2>&1; \
 		aws s3api put-public-access-block --bucket $(TFSTATE_S3_BUCKET) --public-access-block-configuration "BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true" > /dev/null 2>&1; \
 		aws s3api put-bucket-versioning --region $(TFSTATE_REGION) --bucket $(TFSTATE_S3_BUCKET) --versioning-configuration Status=Enabled > /dev/null 2>&1; \
-		echo "Created S3 Bucket $(TFSTATE_S3_BUCKET)."; \
+		echo "Created S3 Bucket $(TFSTATE_S3_BUCKET). Waiting for bucket to be fully available..."; \
+		sleep 10; \
+		until aws s3api head-bucket --region $(TFSTATE_REGION) --bucket $(TFSTATE_S3_BUCKET) > /dev/null 2>&1; do \
+			echo "Waiting for S3 bucket to be available..."; \
+			sleep 5; \
+		done; \
+		echo "S3 Bucket $(TFSTATE_S3_BUCKET) is now available."; \
 	 else \
 		echo "S3 Bucket $(TFSTATE_S3_BUCKET) exists."; \
 	 fi
@@ -123,6 +135,8 @@ init: check-env
 		-backend-config="region=$(TFSTATE_REGION)" \
 		-backend-config="bucket=$(TFSTATE_S3_BUCKET)" \
 		-backend-config="dynamodb_table=$(TFSTATE_DDB_TABLE)" \
+		-var="tfstate_bucket=$(TFSTATE_S3_BUCKET)" \
+		-var="tfstate_region=$(TFSTATE_REGION)" \
 		2>&1 | tee -a tf-logs/$(notdir $(MODULE))-init.log
 
 tf-select-ws:

--- a/single-account-single-cluster-multi-env/README.md
+++ b/single-account-single-cluster-multi-env/README.md
@@ -58,7 +58,7 @@ Each folder that holds a Terraform configuration, also has a `backend.tf` terraf
 Before deploying the whole cluster configuration, this pattern use Amazon S3 and Amazon DynamoDB to store the Terraform state of all resources across environments, and provide a locking mechanism.   
 The deployment of the S3 Bucket and the DynamoDB table is configured in the [`Makefile`](./Makefile) under the `bootstrap` stage.
 
-Default S3 bucket name: `tfstate-<AWS_ACCOUNT_ID>`  
+Default S3 bucket name: `${resources_prefix}-tfstate-${AWS_ACCOUNT_ID}`  
 Default DynamoDB table name: `tfstate-lock`
 
 Several environment variables must be used before running any target


### PR DESCRIPTION
EKS v1.32
Flexible tfstate

*Description of changes:*
Support for EKS v 1.32 
Karpenter helm update to 1.1.2
Flexible tfstate that allows for non-conflicting environments(state regional change is not possible)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
